### PR TITLE
Match multiple issues per line.

### DIFF
--- a/src/jira-linkifier.coffee
+++ b/src/jira-linkifier.coffee
@@ -33,7 +33,7 @@ module.exports = (robot) ->
 
 
   prefixList = prefixes.join('|')
-  ticketRegExp = new RegExp "(^|\\s+)(#{prefixList})-[0-9]+($|\\s+)", "gi"
+  ticketRegExp = new RegExp "(?:\\s)((?:#{prefixes.join('|')})-\\d+)(?:\\s)", "gi"
 
   robot.hear ticketRegExp, (res) ->
     for ticketMatch in res.match

--- a/test/jira-linkifier-test.coffee
+++ b/test/jira-linkifier-test.coffee
@@ -22,9 +22,8 @@ describe 'jira-linkifier', ->
   it "reads HUBOT_JIRA_LINKIFIER_PROJECT_PREFIXES env variable for a list of prefixes to match", ->
     expect(process.env.HUBOT_JIRA_LINKIFIER_PROJECT_PREFIXES).to.equal(@prefixes)
 
-
   it "registers a hear to listener for matching patterns like '<prefix>-<numbers>'", ->
-    ticketRegExp = new RegExp "(^|\\s+)(XXX|YYY|ZZZ)-[0-9]+($|\\s+)", "gi"
+    ticketRegExp = new RegExp "(?:\\s+)(?:XXX|YYY|ZZZ)-[0-9]+(?:\\s+)", "gi"
     expect(@robot.hear).to.have.been.calledWith(ticketRegExp)
 
 


### PR DESCRIPTION
This should fix the issue of multiple matches for an issue that begins the line, and still match multiple issues within the line.